### PR TITLE
Fix NRE in HideEntities patch.

### DIFF
--- a/NitroxClient/ApiHelper.cs
+++ b/NitroxClient/ApiHelper.cs
@@ -1,9 +1,7 @@
 ﻿using NitroxModel.DataStructures.Util;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
+
 
 namespace NitroxClient
 {
@@ -36,11 +34,14 @@ namespace NitroxClient
 
         public static Optional<TechType> TechType(String techTypeString)
         {
-            TechType techType;
-            UWE.Utils.TryParseEnum<TechType>(techTypeString, out techType);
+            UWE.Utils.TryParseEnum(techTypeString, out TechType techType);
 
             return Optional<TechType>.OfNullable(techType);
         }
 
+        public static Int3 Int3(Vector3 v)
+        {
+            return new Int3((int)v.x, (int)v.y, (int)v.z);
+        }
     }
 }

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -8,7 +8,6 @@ using NitroxModel.Packets;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace NitroxClient.MonoBehaviours
@@ -158,11 +157,11 @@ namespace NitroxClient.MonoBehaviours
             }
         }
 
-        public static void RemoveChunk(Vector3 chunk)
+        public static void RemoveChunk(VoxelandChunk chunk)
         {
-            if (chunk != null && loadedChunks != null)
+            if (chunk?.transform != null && loadedChunks != null)
             {
-                Int3 owningChunk = new Int3((int)chunk.x, (int)chunk.y, (int)chunk.z);
+                Int3 owningChunk = ApiHelper.Int3(chunk.transform.position);
                 loadedChunks.RemoveChunk(owningChunk);
             }
         }

--- a/NitroxPatcher/Main.cs
+++ b/NitroxPatcher/Main.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Harmony;
 using System.Reflection;
 using NitroxPatcher.Patches;
-using NitroxModel.Helper;
 
 namespace NitroxPatcher
 {
@@ -25,6 +22,9 @@ namespace NitroxPatcher
         public static void Execute()
         {
             Console.WriteLine("Patching subnautica for nitrox");
+            // Enabling this creates a log file on your desktop (why there?), showing the emitted IL instructions.
+            HarmonyInstance.DEBUG = false;
+
             HarmonyInstance harmony = HarmonyInstance.Create("com.nitroxmod.harmony");
 
             foreach(NitroxPatch patch in patches)

--- a/NitroxTest/Patcher/Patches/BuilderPatchTest.cs
+++ b/NitroxTest/Patcher/Patches/BuilderPatchTest.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NitroxPatcher.Patches;
 using Harmony;
-using System.Reflection.Emit;
 using System.Reflection;
-using Harmony.ILCopying;
-using NitroxModel.Helper;
 using NitroxTest.Patcher.Test;
 
 namespace NitroxTest.Patcher.Patches
@@ -23,7 +18,7 @@ namespace NitroxTest.Patcher.Patches
             instructions.Add(new CodeInstruction(BuilderPatch.INJECTION_OPCODE, BuilderPatch.INJECTION_OPERAND));
 
             IEnumerable<CodeInstruction> result = BuilderPatch.Transpiler(null, instructions);
-            Assert.AreEqual(113, PatchTestHelper.GetInstructionCount(result));
+            Assert.AreEqual(113, result.Count());
         }
 
         [TestMethod]
@@ -33,7 +28,7 @@ namespace NitroxTest.Patcher.Patches
             List<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(targetMethod);
 
             IEnumerable<CodeInstruction> result = BuilderPatch.Transpiler(targetMethod, beforeInstructions);
-            Assert.IsTrue(beforeInstructions.Count < PatchTestHelper.GetInstructionCount(result));
+            Assert.IsTrue(beforeInstructions.Count < result.Count());
         }
     }
 }

--- a/NitroxTest/Patcher/Patches/ClipMapManager_HideEntities_PatchTest.cs
+++ b/NitroxTest/Patcher/Patches/ClipMapManager_HideEntities_PatchTest.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NitroxPatcher.Patches;
 using Harmony;
-using System.Reflection.Emit;
-using System.Reflection;
-using Harmony.ILCopying;
-using NitroxModel.Helper;
-using NitroxPatcher;
 using NitroxTest.Patcher.Test;
 
 namespace NitroxTest.Patcher.Patches
@@ -17,13 +9,15 @@ namespace NitroxTest.Patcher.Patches
     [TestClass]
     public class ClipMapManager_HideEntities_PatchTest
     {
+        // TODO: Pass a valid ILGenerator instead of null.
+
         [TestMethod]
         public void Sanity()
         {
             List<CodeInstruction> instructions = PatchTestHelper.GenerateDummyInstructions(100);
             instructions.Add(new CodeInstruction(ClipMapManager_HideEntities_Patch.INJECTION_OPCODE, null));
 
-            IEnumerable<CodeInstruction> result = ClipMapManager_HideEntities_Patch.Transpiler(null, instructions);
+            IEnumerable<CodeInstruction> result = ClipMapManager_HideEntities_Patch.Transpiler(null, null, instructions);
             Assert.AreEqual(106, PatchTestHelper.GetInstructionCount(result));
         }
 
@@ -32,7 +26,7 @@ namespace NitroxTest.Patcher.Patches
         {
             List<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(ClipMapManager_HideEntities_Patch.TARGET_METHOD);
 
-            IEnumerable<CodeInstruction> result = ClipMapManager_HideEntities_Patch.Transpiler(ClipMapManager_HideEntities_Patch.TARGET_METHOD, beforeInstructions);
+            IEnumerable<CodeInstruction> result = ClipMapManager_HideEntities_Patch.Transpiler(ClipMapManager_HideEntities_Patch.TARGET_METHOD, null, beforeInstructions);
 
             Assert.IsTrue(beforeInstructions.Count < PatchTestHelper.GetInstructionCount(result));
         }

--- a/NitroxTest/Patcher/Patches/ClipMapManager_HideEntities_PatchTest.cs
+++ b/NitroxTest/Patcher/Patches/ClipMapManager_HideEntities_PatchTest.cs
@@ -3,22 +3,22 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NitroxPatcher.Patches;
 using Harmony;
 using NitroxTest.Patcher.Test;
+using System.Linq;
 
 namespace NitroxTest.Patcher.Patches
 {
     [TestClass]
     public class ClipMapManager_HideEntities_PatchTest
     {
-        // TODO: Pass a valid ILGenerator instead of null.
-
         [TestMethod]
         public void Sanity()
         {
             List<CodeInstruction> instructions = PatchTestHelper.GenerateDummyInstructions(100);
             instructions.Add(new CodeInstruction(ClipMapManager_HideEntities_Patch.INJECTION_OPCODE, null));
 
-            IEnumerable<CodeInstruction> result = ClipMapManager_HideEntities_Patch.Transpiler(null, null, instructions);
-            Assert.AreEqual(106, PatchTestHelper.GetInstructionCount(result));
+            IEnumerable<CodeInstruction> result = ClipMapManager_HideEntities_Patch.Transpiler(null, instructions);
+
+            Assert.AreEqual(instructions.Count + 3, result.Count());
         }
 
         [TestMethod]
@@ -26,9 +26,11 @@ namespace NitroxTest.Patcher.Patches
         {
             List<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(ClipMapManager_HideEntities_Patch.TARGET_METHOD);
 
-            IEnumerable<CodeInstruction> result = ClipMapManager_HideEntities_Patch.Transpiler(ClipMapManager_HideEntities_Patch.TARGET_METHOD, null, beforeInstructions);
+            IEnumerable<CodeInstruction> result = ClipMapManager_HideEntities_Patch.Transpiler(ClipMapManager_HideEntities_Patch.TARGET_METHOD, beforeInstructions);
 
-            Assert.IsTrue(beforeInstructions.Count < PatchTestHelper.GetInstructionCount(result));
+            Assert.IsTrue(beforeInstructions.Count < result.Count());
+            // 3 instructions are added for every ret, currently there are two.
+            Assert.AreEqual(beforeInstructions.Count + 6, result.Count());
         }
     }
 }

--- a/NitroxTest/Patcher/Patches/ClipMapManager_ShowEntities_PatchTest.cs
+++ b/NitroxTest/Patcher/Patches/ClipMapManager_ShowEntities_PatchTest.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NitroxPatcher.Patches;
 using Harmony;
-using System.Reflection.Emit;
-using System.Reflection;
-using Harmony.ILCopying;
-using NitroxModel.Helper;
-using NitroxPatcher;
 using NitroxTest.Patcher.Test;
 
 namespace NitroxTest.Patcher.Patches
@@ -24,7 +17,7 @@ namespace NitroxTest.Patcher.Patches
             instructions.Add(new CodeInstruction(ClipMapManager_ShowEntities_Patch.INJECTION_OPCODE, null));
 
             IEnumerable<CodeInstruction> result = ClipMapManager_ShowEntities_Patch.Transpiler(null, instructions);
-            Assert.AreEqual(108, PatchTestHelper.GetInstructionCount(result));
+            Assert.AreEqual(108, result.Count());
         }
 
         [TestMethod]
@@ -34,7 +27,7 @@ namespace NitroxTest.Patcher.Patches
 
             IEnumerable<CodeInstruction> result = ClipMapManager_ShowEntities_Patch.Transpiler(ClipMapManager_ShowEntities_Patch.TARGET_METHOD, beforeInstructions);
 
-            Assert.IsTrue(beforeInstructions.Count < PatchTestHelper.GetInstructionCount(result));
+            Assert.IsTrue(beforeInstructions.Count < result.Count());
         }
 
         /* TODO: Figure out E-Call errors: 

--- a/NitroxTest/Patcher/Patches/Constructable_Construct_PatchTest.cs
+++ b/NitroxTest/Patcher/Patches/Constructable_Construct_PatchTest.cs
@@ -1,39 +1,35 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NitroxPatcher.Patches;
 using Harmony;
-using System.Reflection.Emit;
 using System.Reflection;
-using Harmony.ILCopying;
-using NitroxModel.Helper;
 using NitroxTest.Patcher.Test;
+using System.Linq;
 
 namespace NitroxTest.Patcher.Patches
 {
     [TestClass]
     public class Constructable_Construct_PatchTest
     {
-        [TestMethod]
+        // Constructable_Construct_Patch is currently commented out, so the unittests don't work.
+        //[TestMethod]
         public void Sanity()
         {
             List<CodeInstruction> instructions = PatchTestHelper.GenerateDummyInstructions(100);
             instructions.Add(new CodeInstruction(Constructable_Construct_Patch.INJECTION_OPCODE, Constructable_Construct_Patch.INJECTION_OPERAND));
 
             IEnumerable<CodeInstruction> result = Constructable_Construct_Patch.Transpiler(null, instructions);
-            Assert.AreEqual(111, PatchTestHelper.GetInstructionCount(result));
+            Assert.AreEqual(111, result.Count());
         }
 
-        [TestMethod]
+        //[TestMethod]
         public void InjectionSanity()
         {
             MethodInfo targetMethod = AccessTools.Method(typeof(Constructable), "Construct");
             List<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(targetMethod);
 
             IEnumerable<CodeInstruction> result = Constructable_Construct_Patch.Transpiler(targetMethod, beforeInstructions);
-            Assert.IsTrue(beforeInstructions.Count < PatchTestHelper.GetInstructionCount(result));
+            Assert.IsTrue(beforeInstructions.Count < result.Count());
         }
     }
 }

--- a/NitroxTest/Patcher/Test/PatchTestHelper.cs
+++ b/NitroxTest/Patcher/Test/PatchTestHelper.cs
@@ -1,29 +1,14 @@
 ﻿using Harmony;
 using Harmony.ILCopying;
 using NitroxModel.Helper;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
 
 namespace NitroxTest.Patcher.Test
 {
     public static class PatchTestHelper
     {
-        public static int GetInstructionCount(IEnumerable<CodeInstruction> result)
-        {
-            int instructionCounter = 0;
-
-            foreach (CodeInstruction instruction in result)
-            {
-                instructionCounter++;
-            }
-
-            return instructionCounter;
-        }
-
         public static List<CodeInstruction> GenerateDummyInstructions(int count)
         {
             List<CodeInstruction> instructions = new List<CodeInstruction>();


### PR DESCRIPTION
Checks for nullity on `VoxelandChunk`s returned by `get_chunks`.