### PR TITLE
Fixed warnings and messages.

### DIFF
--- a/ClientTester/MultiplayerClient.cs
+++ b/ClientTester/MultiplayerClient.cs
@@ -26,7 +26,7 @@ namespace ClientTester
         public void Start(String ip)
         {
             client.Start(ip);
-            if (client.isConnected())
+            if (client.IsConnected())
             {
                 PacketSender.Active = true;
                 PacketSender.Authenticate();

--- a/ClientTester/Program.cs
+++ b/ClientTester/Program.cs
@@ -16,6 +16,7 @@ namespace ClientTester
 
         private static Vector3 clientPos = new Vector3(-50f, -2f, -38f);
 
+        [STAThread]
         static void Main(string[] args)
         {
             String playerId1 = "sunrunner";

--- a/NitroxClient/Communication/ChunkAwarePacketReceiver.cs
+++ b/NitroxClient/Communication/ChunkAwarePacketReceiver.cs
@@ -52,17 +52,15 @@ namespace NitroxClient.Communication
         
         private bool PacketWasDeferred(Packet packet)
         {
-            if (packet is PlayerActionPacket)
+            if (packet is PlayerActionPacket playerAction)
             {
-                PlayerActionPacket playerAction = (PlayerActionPacket)packet;
-
                 if (!playerAction.PlayerMustBeInRangeToReceive)
                 {
                     return false;
                 }
 
                 Int3 actionChunk = loadedChunks.GetChunk(playerAction.ActionPosition);
-                    
+
                 if (!loadedChunks.IsLoadedChunk(actionChunk))
                 {
                     Console.WriteLine("Action was deferred, chunk not loaded: " + actionChunk);

--- a/NitroxClient/Communication/Client.cs
+++ b/NitroxClient/Communication/Client.cs
@@ -43,26 +43,26 @@ namespace NitroxClient.Communication
 
                 if (!socket.Connected)
                 {
-                    outputMessage("Unable to connect to server.");
+                    OutputMessage("Unable to connect to server.");
                     throw new InvalidOperationException("Socket could not connect.");
                 }
                 else
                 {
-                    outputMessage("Connected to server.");
+                    OutputMessage("Connected to server.");
                 }
 
                 connection.BeginReceive(new AsyncCallback(DataReceived));
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                outputMessage("Unable to connect to server");
+                OutputMessage("Unable to connect to server");
             }
         }
 
         public void Stop()
         {
             connection.Close(); // Server will clean up pretty quickly
-            outputMessage("Disconnected from server.");
+            OutputMessage("Disconnected from server.");
         }
         
         private void DataReceived(IAsyncResult ar)
@@ -94,7 +94,7 @@ namespace NitroxClient.Communication
 
         }
 
-        public bool isConnected()
+        public bool IsConnected()
         {
             if (connection == null)
             {
@@ -103,7 +103,7 @@ namespace NitroxClient.Communication
             return connection.Open;
         }
 
-        private void outputMessage(String msg)
+        private void OutputMessage(String msg)
         {
             if (testClient)
             {

--- a/NitroxClient/Communication/Packets/Processors/VehicleMovementProcessor.cs
+++ b/NitroxClient/Communication/Packets/Processors/VehicleMovementProcessor.cs
@@ -27,7 +27,7 @@ namespace NitroxClient.Communication.Packets.Processors
 
             if(opGameObject.IsEmpty())
             {
-                opGameObject = createVehicle(vehicleMovement.TechType, vehicleMovement.Guid);
+                opGameObject = CreateVehicle(vehicleMovement.TechType, vehicleMovement.Guid);
 
                 if(opGameObject.IsEmpty())
                 {
@@ -43,7 +43,7 @@ namespace NitroxClient.Communication.Packets.Processors
             MovementHelper.MoveGameObject(gameObject, position, rotation, VEHICLE_TRANSFORM_SMOOTH_PERIOD);
         }
 
-        private Optional<GameObject> createVehicle(String techTypeString, String guid)
+        private Optional<GameObject> CreateVehicle(String techTypeString, String guid)
         {
             Optional<TechType> opTechType = ApiHelper.TechType(techTypeString);
             

--- a/NitroxClient/GameLogic/PlayerGameObjectManager.cs
+++ b/NitroxClient/GameLogic/PlayerGameObjectManager.cs
@@ -53,12 +53,12 @@ namespace NitroxClient.GameLogic
             GameObject player = FindPlayerGameObject(playerId);
             if (player == null)
             {
-                player = gameObjectByPlayerId[playerId] = createOtherPlayer(playerId);
+                player = gameObjectByPlayerId[playerId] = CreateOtherPlayer(playerId);
             }
             return player;
         }
 
-        private GameObject createOtherPlayer(string playerId)
+        private GameObject CreateOtherPlayer(string playerId)
         {
             GameObject body = GameObject.Find("body");
             //Cheap fix for showing head, much easier since male_geo contains many different heads

--- a/NitroxClient/MonoBehaviours/Multiplayer.cs
+++ b/NitroxClient/MonoBehaviours/Multiplayer.cs
@@ -52,7 +52,7 @@ namespace NitroxClient.MonoBehaviours
 
         public void Update()
         {
-            if (client != null && client.isConnected())
+            if (client != null && client.IsConnected())
             {
                 ProcessPackets();
             }
@@ -78,7 +78,7 @@ namespace NitroxClient.MonoBehaviours
         
         public void OnConsoleCommand_mplayer(NotificationCenter.Notification n)
         {
-            if (client.isConnected())
+            if (client.IsConnected())
             {
                 ErrorMessage.AddMessage("Already connected to a server");
             } 
@@ -133,7 +133,7 @@ namespace NitroxClient.MonoBehaviours
 
         private void StopMultiplayer()
         {
-            if (client.isConnected())
+            if (client.IsConnected())
             {
                 client.Stop();
                 PacketSender.Active = false;

--- a/NitroxModel/Tcp/Connection.cs
+++ b/NitroxModel/Tcp/Connection.cs
@@ -36,7 +36,7 @@ namespace NitroxModel.Tcp
             {
                 bytesRead = Socket.EndReceive(ar);
             }
-            catch (SocketException se)
+            catch (SocketException)
             {
                 Console.WriteLine("Error reading data from socket");
                 Open = false;
@@ -65,7 +65,7 @@ namespace NitroxModel.Tcp
                 {
                     Socket.BeginSend(packetData, 0, packetData.Length, 0, callback, Socket);
                 }
-                catch (SocketException se)
+                catch (SocketException)
                 {
                     Console.WriteLine("Error sending packet");
                     Open = false;
@@ -81,7 +81,7 @@ namespace NitroxModel.Tcp
                 Socket.Shutdown(SocketShutdown.Both);
                 Socket.Close();
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Console.WriteLine("Error closing socket -- probably already closed");
             }

--- a/NitroxServer/Listener.cs
+++ b/NitroxServer/Listener.cs
@@ -24,14 +24,17 @@ namespace NitroxServer
 
         public Listener()
         {
-            packetForwardBlacklist = new HashSet<Type>();
-            packetForwardBlacklist.Add(typeof(Authenticate));
-
-            loggingPacketBlackList = new HashSet<Type>();
-            loggingPacketBlackList.Add(typeof(AnimationChangeEvent));
-            loggingPacketBlackList.Add(typeof(Movement));
-            loggingPacketBlackList.Add(typeof(VehicleMovement));
-            loggingPacketBlackList.Add(typeof(ItemPosition));
+            packetForwardBlacklist = new HashSet<Type>
+            {
+                typeof(Authenticate)
+            };
+            loggingPacketBlackList = new HashSet<Type>
+            {
+                typeof(AnimationChangeEvent),
+                typeof(Movement),
+                typeof(VehicleMovement),
+                typeof(ItemPosition)
+            };
         }
 
         public void Start()
@@ -62,7 +65,7 @@ namespace NitroxServer
             
             foreach(Packet packet in connection.GetPacketsFromRecievedData(ar))
             {
-                Player player = getPlayer(packet, connection);
+                Player player = GetPlayer(packet, connection);
                 connection.PlayerId = player.Id;
                 UpdatePlayerPosition(player, packet);
 
@@ -80,11 +83,11 @@ namespace NitroxServer
             }
             else
             {
-                playerDisconnected(connection.PlayerId);
+                PlayerDisconnected(connection.PlayerId);
             }
         }
 
-        private Player getPlayer(Packet packet, Connection connection)
+        private Player GetPlayer(Packet packet, Connection connection)
         {
             Player player;
 
@@ -134,7 +137,7 @@ namespace NitroxServer
                 Socket handler = (Socket)ar.AsyncState;                
                 int bytesSent = handler.EndSend(ar);
             }
-            catch (SocketException e)
+            catch (SocketException)
             {
                 Console.WriteLine("Listener: Error sending packet");
             }
@@ -144,7 +147,7 @@ namespace NitroxServer
             }
         }
 
-        private void playerDisconnected(String PlayerId)
+        private void PlayerDisconnected(String PlayerId)
         {
             if (PlayerId != null)
             {


### PR DESCRIPTION
Gets rid of all the warnings and 'informative' messages that are shown on the current master branch.

Some are C#6/7 specific, so we should discuss which version we want to support at a minimum. I'll remove those changes once we've settled on a version. Some of the messages are about improper naming, as currently `lowerCamelCasing` is sometimes used for private methods, whilst visual studio is set to `UpperCamelCasing` to default. IMHO it doesn't matter which one we use, as long as we stay consistent. A styleguide would be really helpful (perhaps a config for VS if such a thing is even possible?).

Also, I think we should enforce that PR code is free of warnings. Those on the current master branch are harmless (unused variables), but more serious ones will get lost in a pile of these. And it forces everyone to keep their code clean.

In the end, this PR is not so much about getting these changes in to the master branch but showing which pieces of code VS complains about, and to get a discussion started about this topic.

Some more things which VS doesn't really complain about, but are shown a bit faded/greyed-out, and are generally not that nice to see:

- Superfluous use of `this.`;
- Unnecessary cast;
- Unused using statements;
- Unsorted using statements.

These should be covered in the styleguide as well.