### PR TITLE
Cyclops sonar basic sync

### DIFF
--- a/Nitrox.Test/Patcher/PatchTestHelper.cs
+++ b/Nitrox.Test/Patcher/PatchTestHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
@@ -36,13 +36,17 @@ namespace NitroxTest.Patcher
 
         public static IEnumerable<KeyValuePair<OpCode, object>> GetILInstructions(MethodInfo method)
         {
-            DynamicMethod dynMethod = new DynamicMethod(method.Name, method.ReturnType, method.GetParameters().Select(p => p.ParameterType).ToArray(), false);
-            return PatchProcessor.ReadMethodBody(method, dynMethod.GetILGenerator());
+            return PatchProcessor.ReadMethodBody(method, method.GetILGenerator());
         }
 
         public static IEnumerable<KeyValuePair<OpCode, object>> GetILInstructions(DynamicMethod method)
         {
             return PatchProcessor.ReadMethodBody(method, method.GetILGenerator());
+        }
+
+        public static ILGenerator GetILGenerator(this MethodInfo method)
+        {
+            return new DynamicMethod(method.Name, method.ReturnType, method.GetParameters().Types()).GetILGenerator();
         }
 
         public static void TestPattern(MethodInfo targetMethod, InstructionsPattern pattern, out IEnumerable<CodeInstruction> originalIl, out IEnumerable<CodeInstruction> transformedIl)

--- a/Nitrox.Test/Patcher/Patches/Dynamic/CyclopsSonarButton_Update_PatchTest.cs
+++ b/Nitrox.Test/Patcher/Patches/Dynamic/CyclopsSonarButton_Update_PatchTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection.Emit;
@@ -20,15 +20,15 @@ public class CyclopsSonarButton_Update_PatchTest
         instructions.Add(new CodeInstruction(OpCodes.Callvirt, Reflect.Method((Player player) => player.GetMode())));
         instructions.Add(new CodeInstruction(OpCodes.Brtrue));
 
-        IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(null, instructions);
-        Assert.AreEqual(instructions.Count + 2, result.Count());
+        IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(CyclopsSonarButton_Update_Patch.TARGET_METHOD, instructions, CyclopsSonarButton_Update_Patch.TARGET_METHOD.GetILGenerator());
+        Assert.AreEqual(instructions.Count + 3, result.Count());
     }
 
     [TestMethod]
     public void InjectionSanity()
     {
-        ReadOnlyCollection<CodeInstruction> beforeInstructions = PatchTestHelper.GetInstructionsFromMethod(CyclopsSonarButton_Update_Patch.TARGET_METHOD);
-        IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(CyclopsSonarButton_Update_Patch.TARGET_METHOD, beforeInstructions);
+        List<CodeInstruction> beforeInstructions = PatchProcessor.GetCurrentInstructions(CyclopsSonarButton_Update_Patch.TARGET_METHOD);
+        IEnumerable<CodeInstruction> result = CyclopsSonarButton_Update_Patch.Transpiler(CyclopsSonarButton_Update_Patch.TARGET_METHOD, beforeInstructions, CyclopsSonarButton_Update_Patch.TARGET_METHOD.GetILGenerator());
 
         Assert.IsTrue(beforeInstructions.Count < result.Count());
     }

--- a/NitroxClient/GameLogic/Cyclops.cs
+++ b/NitroxClient/GameLogic/Cyclops.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NitroxClient.Communication.Abstract;
@@ -19,7 +19,6 @@ namespace NitroxClient.GameLogic
         private readonly IPacketSender packetSender;
         private readonly Vehicles vehicles;
         private readonly Entities entities;
-        private static List<NitroxId> skipSonarTurnoff = new();
 
         public Cyclops(IPacketSender packetSender, Vehicles vehicles, Entities entities)
         {
@@ -186,12 +185,6 @@ namespace NitroxClient.GameLogic
                     }
                 }
             }
-        }
-
-        public bool ShouldSonarTurnoff(NitroxId cyclopsId)
-        {
-            // Return the opposite because, if we want to skip the turnoff (true), we should not turn it off (false)
-            return !skipSonarTurnoff.Contains(cyclopsId);
         }
     }
 }

--- a/NitroxClient/GameLogic/Spawning/Metadata/CyclopsMetadataProcessor.cs
+++ b/NitroxClient/GameLogic/Spawning/Metadata/CyclopsMetadataProcessor.cs
@@ -123,13 +123,19 @@ public class CyclopsMetadataProcessor : GenericEntityMetadataProcessor<CyclopsMe
         }
     }
 
-    private void ChangeSonarMode(GameObject cyclops, bool isOn)
+    public void ChangeSonarMode(GameObject cyclops, bool isOn)
     {
         CyclopsSonarButton sonarButton = cyclops.GetComponentInChildren<CyclopsSonarButton>(true);
-
-        if (sonarButton)
+        if (sonarButton && sonarButton.sonarActive != isOn)
         {
-            sonarButton.sonarActive = isOn;            
+            if (isOn)
+            {
+                sonarButton.TurnOnSonar();
+            }
+            else
+            {
+                sonarButton.TurnOffSonar();
+            }
         }
     }
 

--- a/NitroxClient/MonoBehaviours/MultiplayerCyclops.cs
+++ b/NitroxClient/MonoBehaviours/MultiplayerCyclops.cs
@@ -1,8 +1,8 @@
-﻿using NitroxClient.GameLogic;
+using NitroxClient.GameLogic;
 
 namespace NitroxClient.MonoBehaviours
 {
-    class MultiplayerCyclops : MultiplayerVehicleControl
+    public class MultiplayerCyclops : MultiplayerVehicleControl
     {
         private ISubTurnHandler[] subTurnHandlers;
         private ISubThrottleHandler[] subThrottleHandlers;

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_SonarPing_Patch.cs
@@ -1,138 +1,42 @@
-﻿using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Reflection.Emit;
 using HarmonyLib;
 using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.Core;
-using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
-namespace NitroxPatcher.Patches.Dynamic
+namespace NitroxPatcher.Patches.Dynamic;
+
+/// <summary>
+/// The sonar will stay on until the player leaves the vehicle and automatically turns on when they enter again (if sonar was on at that time).
+/// </summary>
+public class CyclopsSonarButton_SonarPing_Patch : NitroxPatch, IDynamicPatch
 {
-    /// <summary>
-    /// The sonar will stay on until the player leaves the vehicle and automatically turns on when they enter again (if sonar was on at that time).
-    /// </summary>
-    public class CyclopsSonarButton_SonarPing_Patch : NitroxPatch, IDynamicPatch
+    private static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsSonarButton t) => t.SonarPing());
+
+    public static bool Prefix(CyclopsSonarButton __instance)
     {
-        public static readonly MethodInfo TARGET_METHOD = Reflect.Method((CyclopsSonarButton t) => t.SonarPing());
-        public static readonly OpCode JUMP_TARGET_CODE = OpCodes.Ldsfld;
-        public static readonly FieldInfo JUMP_TARGET_FIELD = Reflect.Field(() => SNCameraRoot.main);
-
-
-        // Send ping to other players        
-        public static void Postfix(CyclopsSonarButton __instance)
+        SubRoot subRoot = __instance.subRoot;
+        if (Player.main.currentSub != subRoot)
         {
-            NitroxId id = NitroxEntity.GetId(__instance.subRoot.gameObject);
-            Resolve<Cyclops>().BroadcastMetadataChange(id);
+            return false;
         }
-
-
-        /* As the ping would be always be executed it should be restricted to players, that are in the cyclops
-        * Therefore the code generated from AssembleNewCode will be injected before the ping would be send but after energy consumption
-        * End result:
-        * private void SonarPing()
-        * {
-        * 	float num = 0f;
-        * 	if (!this.subRoot.powerRelay.ConsumeEnergy(this.subRoot.sonarPowerCost, out num))
-        * 	{
-        * 	    this.TurnOffSonar();
-        * 	    return;
-        * 	}
-        * 	if(Player.main.currentSub != this.subroot)
-        * 	{
-        * 	    return;
-        * 	}
-        * 	SNCameraRoot.main.SonarPing();
-        * 	this.soundFX.Play();
-        * }
-        */
-        public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions, ILGenerator iLGenerator)
+        if (LocalPlayerHasLock(subRoot) && !subRoot.powerRelay.ConsumeEnergy(subRoot.sonarPowerCost, out float _))
         {
-            List<CodeInstruction> instructionList = instructions.ToList();
-
-            // Need to change the jump target for Brtrue at one point
-            Label toInjectJump = iLGenerator.DefineLabel();
-
-            // Find point to inject if player is in subroot:
-            // SNCameraRoot.main.SonarPing();
-            for (int i = 0; i < instructionList.Count; i++)
-            {
-                CodeInstruction instruction = instructionList[i];
-                if (instruction.opcode.Equals(JUMP_TARGET_CODE) && instruction.operand.Equals(JUMP_TARGET_FIELD))
-                {
-                    Label jumpLabel = instruction.labels[0];
-                    IEnumerable<CodeInstruction> injectInstructions = AssembleNewCode(jumpLabel, toInjectJump);
-                    foreach (CodeInstruction injectInstruction in injectInstructions)
-                    {
-                        yield return injectInstruction;
-                    }
-                }
-
-                /* New jump target will from 
-                 * 
-                 * if (!this.subRoot.powerRelay.ConsumeEnergy(this.subRoot.sonarPowerCost, out num))
-                 * 
-                 * will be new code
-                 */
-                if (instruction.opcode.Equals(OpCodes.Brtrue))
-                {
-                    if (instructionList[i - 1].opcode.Equals(OpCodes.Call) && instructionList[i + 1].opcode.Equals(OpCodes.Ldarg_0))
-                    {
-                        instruction.operand = toInjectJump;
-                    }
-                }
-                yield return instruction;
-            }
+            __instance.TurnOffSonar();
+            return false;
         }
+        SNCameraRoot.main.SonarPing();
+        __instance.soundFX.Play();
+        return false;
+    }
 
-        private static IEnumerable<CodeInstruction> AssembleNewCode(Label outJumpLabel, Label innerJumpLabel)
-        {
-            //Code to inject:
-            /*
-             * if (Player.main.currentSub != this.subRoot)
-		     * {
-			 *  return;
-		     * }
-             * 
-             */
-            List<CodeInstruction> injectInstructions = new();
+    private static bool LocalPlayerHasLock(SubRoot subRoot)
+    {
+        return NitroxEntity.TryGetEntityFrom(subRoot.gameObject, out NitroxEntity entity) && Resolve<SimulationOwnership>().HasExclusiveLock(entity.Id);
+    }
 
-            CodeInstruction instruction = new(OpCodes.Ldsfld);
-            instruction.operand = Reflect.Field(() => Player.main);
-            instruction.labels.Add(innerJumpLabel);
-            injectInstructions.Add(instruction);
-
-            instruction = new CodeInstruction(OpCodes.Callvirt);
-            instruction.operand = Reflect.Property((Player t) => t.currentSub).GetMethod;
-            injectInstructions.Add(instruction);
-
-            instruction = new CodeInstruction(OpCodes.Ldarg_0);
-            injectInstructions.Add(instruction);
-
-            instruction = new CodeInstruction(OpCodes.Ldfld);
-            instruction.operand = Reflect.Field((CyclopsSonarButton t) => t.subRoot);
-            injectInstructions.Add(instruction);
-
-            instruction = new CodeInstruction(OpCodes.Call);
-            // Reflect utility class does not supported getting operator-overload methods.
-            instruction.operand = typeof(UnityEngine.Object).GetMethod("op_Inequality", BindingFlags.Public | BindingFlags.Static);
-            injectInstructions.Add(instruction);
-
-            instruction = new CodeInstruction(OpCodes.Brfalse);
-            instruction.operand = outJumpLabel;
-            injectInstructions.Add(instruction);
-
-            instruction = new CodeInstruction(OpCodes.Ret);
-            injectInstructions.Add(instruction);
-
-            return injectInstructions;
-        }
-
-        public override void Patch(Harmony harmony)
-        {
-            PatchMultiple(harmony, TARGET_METHOD, postfix: true, transpiler: true);
-        }
+    public override void Patch(Harmony harmony)
+    {
+        PatchPrefix(harmony, TARGET_METHOD);
     }
 }

--- a/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
+++ b/NitroxPatcher/Patches/Dynamic/CyclopsSonarButton_Update_Patch.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
-using NitroxClient.GameLogic;
 using NitroxClient.MonoBehaviours;
-using NitroxModel.DataStructures;
 using NitroxModel.Helper;
 
 namespace NitroxPatcher.Patches.Dynamic;
@@ -19,14 +18,7 @@ public class CyclopsSonarButton_Update_Patch : NitroxPatch, IDynamicPatch
     internal static readonly OpCode INJECTION_OPCODE = OpCodes.Ldsfld;
     internal static readonly object INJECTION_OPERAND = Reflect.Field(() => Player.main);
 
-    private static NitroxId currentCyclopsId;
-
-    public static void Prefix(CyclopsSonarButton __instance)
-    {
-        currentCyclopsId = NitroxEntity.GetId(__instance.subRoot.gameObject);
-    }
-
-    public static IEnumerable<CodeInstruction> Transpiler(MethodBase methodBase, IEnumerable<CodeInstruction> instructions)
+    public static IEnumerable<CodeInstruction> Transpiler(MethodBase methodBase, IEnumerable<CodeInstruction> instructions, ILGenerator il)
     {
         /* Normally in the Update()
          * if (Player.main.GetMode() == Player.Mode.Normal && this.sonarActive)
@@ -34,11 +26,15 @@ public class CyclopsSonarButton_Update_Patch : NitroxPatch, IDynamicPatch
          *     this.TurnOffSonar();
          * }
          * this part will be changed into:
-         * if (CyclopsSonarButton_Update_Patch.ShouldTurnOff() && Player.main.GetMode() == Player.Mode.Normal && this.sonarActive)
+         * if (CyclopsSonarButton_Update_Patch.ShouldTurnOff(this) && Player.main.GetMode() == Player.Mode.Normal && this.sonarActive)
          */
-        List<CodeInstruction> codeInstructions = new List<CodeInstruction>(instructions);
-        CodeInstruction callInstruction = new(OpCodes.Call, Reflect.Method(() => ShouldTurnoff()));
-        CodeInstruction brInstruction = new(OpCodes.Brfalse);
+        List<CodeInstruction> codeInstructions = new(instructions);
+        Label brLabel = il.DefineLabel();
+        CodeInstruction loadInstruction = new(OpCodes.Ldarg_0);
+        CodeInstruction callInstruction = new(OpCodes.Call, Reflect.Method(() => ShouldTurnoff(default)));
+        CodeInstruction brInstruction = new(OpCodes.Brfalse, brLabel);
+        codeInstructions.Last().labels.Add(brLabel);
+
         for (int i = 0; i < codeInstructions.Count; i++)
         {
             CodeInstruction instruction = codeInstructions[i];
@@ -49,10 +45,9 @@ public class CyclopsSonarButton_Update_Patch : NitroxPatch, IDynamicPatch
                 CodeInstruction nextBr = codeInstructions[i + 2];
 
                 // The new instruction will be the first of the if statement, so it should take the jump labels that the former first part of the statement had
-                callInstruction.labels = new List<Label>(instruction.labels);
-                instruction.labels.Clear();
-                brInstruction.operand = nextBr.operand;
+                instruction.MoveLabelsTo(loadInstruction);
 
+                yield return loadInstruction;
                 yield return callInstruction;
                 yield return brInstruction;
             }
@@ -60,14 +55,17 @@ public class CyclopsSonarButton_Update_Patch : NitroxPatch, IDynamicPatch
         }
     }
 
-    public static bool ShouldTurnoff()
+    public static bool ShouldTurnoff(CyclopsSonarButton cyclopsSonarButton)
     {
-        return Resolve<Cyclops>().ShouldSonarTurnoff(currentCyclopsId);
+        if (cyclopsSonarButton.subRoot.TryGetComponent(out MultiplayerCyclops multiplayerCyclops))
+        {
+            return !multiplayerCyclops.enabled;
+        }
+        return true;
     }
 
     public override void Patch(Harmony harmony)
     {
-        PatchMultiple(harmony, TARGET_METHOD, prefix: true, transpiler: true);
+        PatchTranspiler(harmony, TARGET_METHOD);
     }
-
 }


### PR DESCRIPTION
- Changed the transpiler to directly use the current instance instead of caching it via a prefix.
- Fixed how sonar was turned on/off
- Cleaned the former way of keeping sonar on when the local player is not driving the cyclops